### PR TITLE
Converts to UTF-8

### DIFF
--- a/OpenRVS/classes/OpenBeacon.uc
+++ b/OpenRVS/classes/OpenBeacon.uc
@@ -1,6 +1,3 @@
-// WARNING: This file must be encoded as "Western (Windows 1252)" and not UTF-8.
-// Otherwise, the Pilcrow Sign (¶) will not be correctly parsed by Unreal Engine.
-
 //class to replace UdpBeacon in serveractors list
 //should allow respondprejoinquery() regardless of server registration state
 //this fixes issues in non-n4 admin servers
@@ -10,9 +7,9 @@
 
 class OpenBeacon extends UdpBeacon transient;
 
-const MOTD_MAX_LEN = 60;//Game can only display this many bytes
+const MARKER_MOTD = "O2";
 
-var string MOTDMarker;
+const MOTD_MAX_LEN = 60;//Game can only display this many bytes
 
 event ReceivedText(IpAddr Addr,string Text)
 {
@@ -30,7 +27,7 @@ event ReceivedText(IpAddr Addr,string Text)
 
 // BuildBeaconText() formats the UDP message for the server beacon protocol.
 // Copied from IpDrv/Classes/UdpBeacon.uc in the 1.56 source code.
-// We have made one change: Local beacon marker ¶O2 returns the server MOTD.
+// We have made one change: Local beacon marker Â¶O2 returns the server MOTD.
 function string BuildBeaconText()
 {
 	local string textData;
@@ -192,14 +189,14 @@ function string BuildBeaconText()
 	motd = pServerOptions.MOTD;
 	if ( len(motd) > MOTD_MAX_LEN )
 		motd = left(motd, MOTD_MAX_LEN);
-	textData = textData @ MOTDMarker @ motd;
+	textData = textData @ getMarker(MARKER_MOTD) @ motd;
 	// End OpenRVS modifications.
 
 	return textData;
 }
 
-defaultproperties
+private function string getMarker(string m)
 {
-	// OpenRVS markers should start with ¶O2 and increase sequentially, e.g ¶O3, ¶O4, etc.
-	MOTDMarker="¶O2"
+	// Chr(182) returns Â¶
+	return Chr(182) $ m;
 }

--- a/OpenRVS/classes/OpenClientBeaconReceiver.uc
+++ b/OpenRVS/classes/OpenClientBeaconReceiver.uc
@@ -1,6 +1,3 @@
-// WARNING: This file must be encoded as "Western (Windows 1252)" and not UTF-8.
-// Otherwise, the Pilcrow Sign (¶) will not be correctly parsed by Unreal Engine.
-
 class OpenClientBeaconReceiver extends ClientBeaconReceiver transient;
 
 //new in 0.8
@@ -43,7 +40,7 @@ event ReceivedText(IpAddr Addr,string Text)
 		{
 			//if we got to this stage, it's a REPORT response
 			//start szthirdword at the first symbol for GrabOption() to work
-			szThirdWord = mid(szThirdWord,InStr(szThirdWord,"¶"));
+			szThirdWord = mid(szThirdWord,InStr(szThirdWord, Chr(182)));
 			class'OpenLogger'.static.DebugLog(left(szThirdWord,20));
 			//send the string to ParseOption() with it as first argument, key to look for the second
 			//eg numplayers = ParseOption(szThirdWord,"keyfornumplayers");
@@ -68,21 +65,24 @@ event ReceivedText(IpAddr Addr,string Text)
 //overridden from parent
 //need to strip out the final space from result
 //also need to add the removed symbol back into result
-function bool GrabOption(out string Options,out string Result)//¶I1 OBSOLETESUPERSTARS.COM ¶F1 RGM
+function bool GrabOption(out string Options,out string Result)//Â¶I1 OBSOLETESUPERSTARS.COM Â¶F1 RGM
 {
-	if ( Left(Options,1) == "¶" )
+	local string pilcrow;
+	pilcrow = Chr(182);//Â¶
+
+	if ( Left(Options,1) == pilcrow )
 	{
 		// Get result.
 		Result = Mid(Options,1);
-		if( InStr(Result,"¶") >= 0 )//I1 OBSOLETESUPERSTARS.COM ¶F1 RGM
-			Result = Left(Result,InStr(Result,"¶")-1);//I1 OBSOLETESUPERSTARS.COM//0.8 strip the space
-			//Result = Left(Result,InStr(Result,"¶"));//I1 OBSOLETESUPERSTARS.COM
-		Result = "¶" $ Result;//0.8 add the symbol back in - ¶I1 OBSOLETESUPERSTARS.COM
+		if( InStr(Result, pilcrow) >= 0 )//I1 OBSOLETESUPERSTARS.COM Â¶F1 RGM
+			Result = Left(Result,InStr(Result, pilcrow)-1);//I1 OBSOLETESUPERSTARS.COM//0.8 strip the space
+			//Result = Left(Result,InStr(Result,"Â¶"));//I1 OBSOLETESUPERSTARS.COM
+		Result = pilcrow $ Result;//0.8 add the symbol back in - Â¶I1 OBSOLETESUPERSTARS.COM
 
 		// Update options.
-		Options = Mid(Options,1);//I1 OBSOLETESUPERSTARS.COM ¶F1 RGM
-		if( InStr(Options,"¶") >= 0 )
-			Options = Mid(Options,InStr(Options,"¶"));//¶F1 RGM
+		Options = Mid(Options,1);//I1 OBSOLETESUPERSTARS.COM Â¶F1 RGM
+		if( InStr(Options, pilcrow) >= 0 )
+			Options = Mid(Options,InStr(Options, pilcrow));//Â¶F1 RGM
 		else
 			Options = "";
 		class'OpenLogger'.static.DebugLog("Got option pair " $ Result);


### PR DESCRIPTION
## Summary

Uses `Chr(182)` to get the pilcrow sign instead of relying on string encoding. Now the entire repo can be UTF-8 without risk.

## Testing

Web UI no longer shows transcode warning: https://github.com/ijemafe/OpenRVS/blob/utf-8/OpenRVS/classes/OpenBeacon.uc

I have tested my compiled build in the following scenarios:

- [x] A client running **my build** against a server running **latest stable version**
- [ ] A client running **latest stable version** against a server running **my build**
- [ ] A client running **my build** against a server running **my build**