### PR TITLE
Removes duplicate Refreshes and cleans up Refresh

### DIFF
--- a/OpenRVS/classes/OpenMultiPlayerWidget.uc
+++ b/OpenRVS/classes/OpenMultiPlayerWidget.uc
@@ -21,7 +21,6 @@ var config string ServerURL;//0.8 server list URL to load
 var config string ServerListURL;//0.8 server list file to load
 
 var bool bServerSuccess;//0.8 got list of servers from online provider
-var int refreshCount;//tracking excess Refresh() calls
 
 // QueryReceivedStartPreJoin() (aka PREJOIN) fires when a server query has
 // completed successfully. It is called by the SendMessage() function. In the
@@ -329,8 +328,6 @@ function Refresh(bool bActivatedByUser)
 {
 	local R6WindowListServerItem CurServer;
 
-	refreshCount++;
-	log("refresh has been called" @ refreshCount @ "times");
 	super.Refresh(bActivatedByUser);//call super first
 
 	//dont do this function if we haven't received a server list OR if the open beacon isn't loaded


### PR DESCRIPTION
## Summary

In the base game, `ShowWindow()` and `GetGSServers()` do not refresh the server list data. This PR removes those calls. The only remaining call was in `Refresh()`, so I merged `QueryForServerInfo()` into `Refresh()`.

There is still one additional `Refresh()` call that I have not tracked down yet.

## Testing

I have tested my compiled build in the following scenarios:

- [x] A client running **my build** against a server running **latest stable version**
- [ ] A client running **latest stable version** against a server running **my build**
- [ ] A client running **my build** against a server running **my build**