### PR TITLE
Add locked to query from each server

### DIFF
--- a/OpenRVS/classes/OpenClientBeaconReceiver.uc
+++ b/OpenRVS/classes/OpenClientBeaconReceiver.uc
@@ -28,6 +28,8 @@ event ReceivedText(IpAddr Addr,string Text)
 	local string sNumP,sMaxP,sGMode,sMapName,sSvrName;
 	//1.3
 	local string sModName;
+	//1.5
+	local bool bSvrLocked;
 	super.ReceivedText(Addr,Text);
 	if ( left(Text,len(BeaconProduct)+1) ~= (BeaconProduct$" ") )
 	{
@@ -54,7 +56,9 @@ event ReceivedText(IpAddr Addr,string Text)
 			//1.3
 			sModName = ParseOption(szThirdWord,ModNameMarker);
 			//1.3 - sModName string added to function in MP menu
-			Widget.ReceiveServerInfo(IpAddrToString(Addr),sNumP,sMaxP,sGMode,sMapName,sSvrName,sModName);//send received info back to server list
+			//1.5 - locked info received here
+			bSvrLocked = bool(ParseOption(szThirdWord,LockedMarker));
+			Widget.ReceiveServerInfo(IpAddrToString(Addr),sNumP,sMaxP,sGMode,sMapName,sSvrName,sModName,bSvrLocked);//send received info back to server list
 			class'OpenLogger'.static.Debug("Server " $ sSvrName $ " at " $ IpAddrToString(Addr) $ " is playing map " $ sMapName $ " in game mode type " $ sGMode $ ". Players: " $ sNumP $ "/" $ sMaxP, self);
 		}
 	}

--- a/OpenRVS/classes/OpenMultiPlayerWidget.uc
+++ b/OpenRVS/classes/OpenMultiPlayerWidget.uc
@@ -399,7 +399,8 @@ function ManageTabSelection(INT _MPTabChoiceID)
 
 //0.8 written
 //1.3 added mod keyword locking
-function ReceiveServerInfo(string sIP,coerce int iNumP,coerce int iMaxP,string sGMode,string sMapName,string sSvrName,string sModName)
+//1.5 receive locked info from specific servers, not master list
+function ReceiveServerInfo(string sIP,coerce int iNumP,coerce int iMaxP,string sGMode,string sMapName,string sSvrName,string sModName,bool bSvrLocked)
 {
 	local R6WindowListServerItem CurServer;
 	local int i;
@@ -421,6 +422,7 @@ function ReceiveServerInfo(string sIP,coerce int iNumP,coerce int iMaxP,string s
 				CurServer.bSameVersion = false;
 			else
 				CurServer.bSameVersion = true;
+			CurServer.bLocked = bSvrLocked;//1.5 added locked here
 			CurServer = none;//break the while loop
 		}
 		else


### PR DESCRIPTION
Now that "Locked" is not needed via the master server list, we should correctly get information about locked status from querying each server.  This update parses for locked status and passes it to the server list in multiplayer widget.

## Summary

ReceiveServerInfo has field added for receiving a bool, uses that to show the locked server icon if needed.  ClientBeaconReceiver now also looks for locked marker in ReceivedText to send to ReceiveServerInfo.

## Testing

I have tested my compiled build in the following scenarios:

- [x] A client running **my build** against a server running **latest stable version**
- [ ] A client running **latest stable version** against a server running **my build**
- [ ] A client running **my build** against a server running **my build**