### PR TITLE
OpenTimer new function improvement

### DIFF
--- a/OpenRVS/classes/OpenTimer.uc
+++ b/OpenRVS/classes/OpenTimer.uc
@@ -2,7 +2,7 @@
 // Example usage:
 //   var OpenTimer Timer;
 //   var int Duration;
-//   Timer = class'OpenTimer'.static.New(OpenMultiPlayerWidget);//OMPW provides clock
+//   Timer = class'OpenTimer'.static.New(LevelInfo);//Level provides clock
 //   Timer.StartTimer("my-timer-id");
 //   Duration = Timer.EndTimer("my-timer-id");
 // Timer IDs are unique. Attempting to create a timer with a repeat ID will not
@@ -21,14 +21,15 @@ const ERR_VALUE = -1;
 
 // Timings stores all timers in the class object
 var private array<Timing> Timings;
-var OpenMultiPlayerWidget LevelSource;//provides clock
+//var OpenMultiPlayerWidget LevelSource;//provides clock
+var LevelInfo LevelSource;//provides clock
 
 // Custom constructor.
-static function OpenTimer New(OpenMultiPlayerWidget OMPW)
+static function OpenTimer New(LevelInfo Entry)
 {
 	local OpenTimer ot;
 	ot = new class'OpenTimer';
-	ot.LevelSource = OMPW;
+	ot.LevelSource = Entry;
 	return ot;
 }
 
@@ -47,7 +48,7 @@ function StartTimer(string id)
 	}
 
 	t.ID = id;
-	t.StartTime = int(LevelSource.GetLevel().TimeSeconds*1000);
+	t.StartTime = int(LevelSource.TimeSeconds*1000);
 	Timings[Timings.Length] = t;//Save this timing entry.
 	class'OpenLogger'.static.Debug("started timer with id" @ t.ID @ "at time" @ t.StartTime, self);
 }
@@ -60,7 +61,7 @@ function int EndTimer(string id)
 	local int endTime;
 	local bool found;
 
-	endTime = int(LevelSource.GetLevel().TimeSeconds*1000);
+	endTime = int(LevelSource.TimeSeconds*1000);
 
 	// Find our timing ID
 	for ( i=0; i<Timings.Length; i++ )
@@ -87,5 +88,5 @@ function int EndTimer(string id)
 // Write the current time (in ms since level start) to the log file.
 function LogTime()
 {
-	class'OpenLogger'.static.Debug("the time is now" @ int(LevelSource.GetLevel().TimeSeconds*1000), self);
+	class'OpenLogger'.static.Debug("the time is now" @ int(LevelSource.TimeSeconds*1000), self);
 }


### PR DESCRIPTION
Lets us pass a levelinfo instead of OMPW to a new OpenTimer.  Makes this class more universal and easy to use in any context.

## Summary

Now has static function OpenTimer New(LevelInfo Entry) so any class that has access to a level info can use timer functions.

## Testing

I have tested my compiled build in the following scenarios:

- [x] A client running **my build** against a server running **latest stable version**
- [ ] A client running **latest stable version** against a server running **my build**
- [ ] A client running **my build** against a server running **my build**